### PR TITLE
Revert "Revert "Merge pull request #7 from vinyldns/fix-env-vars""

### DIFF
--- a/vinyldns.go
+++ b/vinyldns.go
@@ -29,6 +29,10 @@ import (
 // passed in via Makefile
 var version string
 
+const hostFlag = "host"
+const accessKeyFlag = "access-key"
+const secretKeyFlag = "secret-key"
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "vinyldns"
@@ -36,17 +40,17 @@ func main() {
 	app.Usage = "A CLI to the vinyldns DNS-as-a-service API"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:   "host",
+			Name:   hostFlag,
 			Usage:  "vinyldns API Hostname",
 			EnvVar: "VINYLDNS_HOST",
 		},
 		cli.StringFlag{
-			Name:   "access_key, ak",
+			Name:   fmt.Sprintf("%s, ak", accessKeyFlag),
 			Usage:  "vinyldns access key",
 			EnvVar: "VINYLDNS_ACCESS_KEY",
 		},
 		cli.StringFlag{
-			Name:   "secret_key, sk",
+			Name:   fmt.Sprintf("%s, sk", secretKeyFlag),
 			Usage:  "vinyldns secret key",
 			EnvVar: "VINYLDNS_SECRET_KEY",
 		},
@@ -282,7 +286,7 @@ func main() {
 
 func groups(c *cli.Context) error {
 	client := client(c)
-	validateEnv()
+	validateEnv(c)
 	groups, err := client.Groups()
 	if err != nil {
 		return err
@@ -395,7 +399,7 @@ func groupActivity(c *cli.Context) error {
 
 func zones(c *cli.Context) error {
 	client := client(c)
-	validateEnv()
+	validateEnv(c)
 	zones, err := client.Zones()
 	if err != nil {
 		return err
@@ -682,18 +686,26 @@ func recordSetDelete(c *cli.Context) error {
 	return nil
 }
 
-func validateEnv() {
-	required := []string{"VINYLDNS_HOST", "VINYLDNS_ACCESS_KEY", "VINYLDNS_SECRET_KEY"}
+func validateEnv(c *cli.Context) {
+	h := c.GlobalString(hostFlag)
+	ak := c.GlobalString(accessKeyFlag)
+	sk := c.GlobalString(secretKeyFlag)
 	missing := []string{}
 
-	for _, r := range required {
-		if os.Getenv(r) == "" {
-			missing = append(missing, r)
-		}
+	if h == "" {
+		missing = append(missing, h)
+		fmt.Printf("\nPlease pass '--%s' or set 'VINYLDNS_HOST'\n", hostFlag)
+	}
+	if ak == "" {
+		missing = append(missing, h)
+		fmt.Printf("\nPlease pass '--%s' or set 'VINYLDNS_ACCESS_KEY'\n", accessKeyFlag)
+	}
+	if sk == "" {
+		missing = append(missing, h)
+		fmt.Printf("\nPlease pass '--%s' or set 'VINYLDNS_SECRET_KEY'\n", secretKeyFlag)
 	}
 
 	if len(missing) > 0 {
-		fmt.Printf("\nPlease set the following required environment variables:\n\n%s\n", strings.Join(missing, "\n"))
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This seeks to improve the way the CLI flags and env vars work, as well as the messaging when any are absent.