### PR TITLE
Create Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:latest AS builder
+
+RUN go get github.com/vinyldns/vinyldns-cli \
+    && cd /go/src/github.com/vinyldns/vinyldns-cli \
+    && go get github.com/golang/lint/golint \
+    && go get -u github.com/golang/dep/cmd/dep \
+    && dep ensure \
+    && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o vinyldns .
+
+FROM scratch
+
+WORKDIR /root/
+COPY --from=builder /go/src/github.com/vinyldns/vinyldns-cli/vinyldns .
+
+ENTRYPOINT ["./vinyldns"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 FROM golang:latest AS builder
 
-RUN mkdir -p /go/src/github.com/vinyldns/vinyldns-cli \
-    && git clone -b docker-file --single-branch \
-        https://github.com/marekfilip/vinyldns-cli.git \
-        /go/src/github.com/vinyldns/vinyldns-cli \
-    && cd /go/src/github.com/vinyldns/vinyldns-cli \
+COPY . /go/src/github.com/vinyldns/vinyldns-cli
+RUN cd /go/src/github.com/vinyldns/vinyldns-cli \
     && make \
     && for i in $(head -n 2 Makefile); do eval $i; done \
     && cp /go/src/github.com/vinyldns/vinyldns-cli/release/${NAME}_${VERSION}_linux_$(uname -m)_nocgo /go/src/github.com/vinyldns/vinyldns-cli/vinyldns

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM golang:latest AS builder
 
-RUN go get github.com/vinyldns/vinyldns-cli \
+RUN mkdir -p /go/src/github.com/vinyldns/vinyldns-cli \
+    && git clone -b docker-file --single-branch \
+        https://github.com/marekfilip/vinyldns-cli.git \
+        /go/src/github.com/vinyldns/vinyldns-cli \
     && cd /go/src/github.com/vinyldns/vinyldns-cli \
-    && go get github.com/golang/lint/golint \
-    && go get -u github.com/golang/dep/cmd/dep \
-    && dep ensure \
-    && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o vinyldns .
+    && make \
+    && for i in $(head -n 2 Makefile); do eval $i; done \
+    && cp /go/src/github.com/vinyldns/vinyldns-cli/release/${NAME}_${VERSION}_linux_$(uname -m)_nocgo /go/src/github.com/vinyldns/vinyldns-cli/vinyldns
 
 FROM scratch
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ build_releases: deps
 	rm -rf release && mkdir release
 	GOOS=linux  go build -ldflags "-X main.version=$(VERSION)" -o release/$(NAME)_$(VERSION)_linux_$(ARCH)
 	GOOS=darwin go build -ldflags "-X main.version=$(VERSION)" -o release/$(NAME)_$(VERSION)_darwin_$(ARCH)
+	GOOS=linux CGO_ENABLED=0  go build -ldflags "-X main.version=$(VERSION)" -o release/$(NAME)_$(VERSION)_linux_$(ARCH)_nocgo
 
 deps:
 	@go tool cover 2>/dev/null; if [ $$? -eq 3 ]; then \


### PR DESCRIPTION
### Description of the Change

I add a Dockerfile requested by issue #10.

### Why Should This Be In The Package?

It fills the assumptions from #10.

### Benefits

User no longer needs to install/compile app by himself. Application is ready to use immediately.

### Possible Drawbacks

There was no application code changes.

### Verification Process

To verify Dockerfile you need to:

1. change directory, where the Dockerfile is

2. build it `docker build --tag vinyldns:vinyldns-cli .`

3. use it, in example:
```
docker run -e VINYLDNS_HOST="https://some-vinyldns.com" \
  -e VINYLDNS_ACCESS_KEY="123" \
  -e VINYLDNS_SECRET_KEY="456" \
  vinyldns/vinyldns-cli \
  zones
```

### Applicable Issues

I would like to point out that I did not use Makefile for compilation. I am not sure if there is there any sense to compile many releases for docker container if we want to use only one of them. Additionally `scratch` image requires `CGO_ENABLED=0 GOOS=linux GOARCH=amd64` build options to run properly (we had to add one more release to Makefile). 