### PR TITLE
Expanding getRecord functionality

### DIFF
--- a/vinyldns.go
+++ b/vinyldns.go
@@ -733,7 +733,7 @@ func getRecord(recs []vinyldns.Record) string {
 		records = getRecordValue(records, r.Serial, "Serial")
 		records = getRecordValue(records, r.Target, "Target")
 		records = getRecordValue(records, r.Text, "Text")
-		records = getRecordValue(records, r.Type, "Type")
+		records = getRecordValue(records, r.Typ, "Type")
 		records = getRecordValue(records, r.Weight, "Weight")
 	}
 

--- a/vinyldns.go
+++ b/vinyldns.go
@@ -714,18 +714,38 @@ func getRecord(recs []vinyldns.Record) string {
 	records := []string{}
 
 	for _, r := range recs {
-		cname := r.CName
-		address := r.Address
-
-		if cname != "" {
-			records = append(records, "CNAME: "+cname)
-		}
-		if address != "" {
-			records = append(records, "address: "+address)
-		}
+		records = getRecordValue(records, r.Address, "Address")
+		records = getRecordValue(records, r.Algorithm, "Algorithm")
+		records = getRecordValue(records, r.CName, "CNAME")
+		records = getRecordValue(records, r.Exchange, "Exchange")
+		records = getRecordValue(records, r.Expire, "Expire")
+		records = getRecordValue(records, r.Fingerprint, "Fingerprint")
+		records = getRecordValue(records, r.MName, "MNAME")
+		records = getRecordValue(records, r.Minimum, "Minimum")
+		records = getRecordValue(records, r.NSDName, "NSDNAME")
+		records = getRecordValue(records, r.Port, "Port")
+		records = getRecordValue(records, r.Preference, "Preference")
+		records = getRecordValue(records, r.Priority, "Priority")
+		records = getRecordValue(records, r.PTRDName, "PTRDNAME")
+		records = getRecordValue(records, r.Refresh, "Refresh")
+		records = getRecordValue(records, r.Retry, "Retry")
+		records = getRecordValue(records, r.RName, "RNAME")
+		records = getRecordValue(records, r.Serial, "Serial")
+		records = getRecordValue(records, r.Target, "Target")
+		records = getRecordValue(records, r.Text, "Text")
+		records = getRecordValue(records, r.Type, "Type")
+		records = getRecordValue(records, r.Weight, "Weight")
 	}
 
 	return strings.Join(records, "\n")
+}
+
+func getRecordValue(records []string, recordValue interface{}, recordPrepend string) []string {
+	if recordValue != "" {
+		records = append(records, recordPrepend + ": " + recordValue.(string))
+	}
+
+	return records
 }
 
 func userIDList(mems []vinyldns.User) string {

--- a/vinyldns.go
+++ b/vinyldns.go
@@ -733,7 +733,7 @@ func getRecord(recs []vinyldns.Record) string {
 		records = getRecordValue(records, r.Serial, "Serial")
 		records = getRecordValue(records, r.Target, "Target")
 		records = getRecordValue(records, r.Text, "Text")
-		records = getRecordValue(records, r.Typ, "Type")
+		records = getRecordValue(records, r.Type, "Type")
 		records = getRecordValue(records, r.Weight, "Weight")
 	}
 


### PR DESCRIPTION
Adding a function to DRY up the appending of record values and setting up record values for all of the given record value types

### Description of the Change

As per issue #17, I have added in calls for all of the listed record values from the [VinylDNS Record Data Information Table](https://www.vinyldns.io/api/recordset-model.html#record-data).  Given the amount of repetition for the code and all of the possible entries, I also added a function, `getRecordValue`, that performs the check if the record value is an empty string and, if not, then appends it to the `records` list with a prepend string (`CNAME`, `Address`, `Text`, etc) then returns the `records` list.

To note: I noted that the VinylDNS Record Data Information Table references `typ` for SSHFP, which I believe is a typo, instead should be `type`.  This is corroborated by the fact that, when I tried to pull up the record value of `typ`, it gave an error, but `type` works.

### Why Should This Be In The Package?

It fully expands on the possible record data information that Vinyl DNS provides.

### Benefits

Allowing the user to get data for the full set of record data information provided by Vinyl DNS.

### Possible Drawbacks

This is the first golang PR I've created, and my experience with golang is rather narrow.  I noted that during the compilation process, the following record types were listed as `int` and, in such, I had to change the accepted `recordValue` argument from `string` to `interface{}`, which I then cast to a `string` when appending to the `records` list.  I'm not sure how those tend to be reflected normally, so it may be that they are appended even with a default value (0, perhaps?) since they would technically not be a `string`

### Verification Process

Unfortunately I do not have a way to realistically test the changes directly.  I ensured that the project properly compiled with no errors prior to creating the PR.

### Applicable Issues (Optional)

Closes #17
