### PR TITLE
enable to use both of cname and address in record-set-create #16

### DIFF
--- a/vinyldns.go
+++ b/vinyldns.go
@@ -649,16 +649,27 @@ func recordSetCreate(c *cli.Context) error {
 	}
 
 	rdata := strings.Split(rdataS, ",")
-	rs := &vinyldns.RecordSet{
-		ZoneID: c.String("zone-id"),
-		Name:   c.String("record-set-name"),
-		Type:   t,
-		TTL:    c.Int("record-set-ttl"),
-		Records: []vinyldns.Record{
+
+	var record []vinyldns.Record
+	if t == "CNAME" {
+		record = []vinyldns.Record{
+			{
+				CName: rdata[0],
+			},
+		}
+	} else {
+		record = []vinyldns.Record{
 			{
 				Address: rdata[0],
 			},
-		},
+		}
+	}
+	rs := &vinyldns.RecordSet{
+		ZoneID:  c.String("zone-id"),
+		Name:    c.String("record-set-name"),
+		Type:    t,
+		TTL:     c.Int("record-set-ttl"),
+		Records: record,
 	}
 
 	_, err = client.RecordSetCreate(c.String("zone-id"), rs)


### PR DESCRIPTION
### Description of the Change

When the cli is doing record-set-create, it can only available to use A or AAAA in record.


### Why Should This Be In The Package?

For resolve #16 

### Benefits

User can be able to set a record both address and cname when they create recode set


### Applicable Issues (Optional)

#16 