### PR TITLE
Fix Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:latest AS builder
 
 COPY . /go/src/github.com/vinyldns/vinyldns-cli
 RUN cd /go/src/github.com/vinyldns/vinyldns-cli \
-    && make \
+    && make build-releases \
     && for i in $(head -n 2 Makefile); do eval $i; done \
     && cp /go/src/github.com/vinyldns/vinyldns-cli/release/${NAME}_${VERSION}_linux_$(uname -m)_nocgo /go/src/github.com/vinyldns/vinyldns-cli/vinyldns
 


### PR DESCRIPTION
Acceptance tests will not run in `docker build`, as they rely on `docker-compose`.
TravisCI can be tasked in running acc tests; there's
arguably no need to run them during the `docker build`,
provided they've passed in CI.