### PR TITLE
verify docker builds in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 
+services:
+  - docker
+
 go:
   - 1.10.3
   - tip

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BATS=github.com/sstephenson/bats
 VINYLDNS_REPO=github.com/vinyldns/vinyldns
 SRC=src/*.go
 
-all: lint vet acceptance stop-api build-releases
+all: lint vet acceptance stop-api docker build-releases
 
 install: build
 	mkdir -p $(PREFIX)/bin


### PR DESCRIPTION
This seeks to ensure against overlooked broken `docker build`s by `docker build`-ing in CI.