### PR TITLE
support MX, PTR and TXT record types

### DIFF
--- a/src/record_sets.go
+++ b/src/record_sets.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+  "strconv"
 
 	clitable "github.com/crackcomm/go-clitable"
 	"github.com/urfave/cli"
@@ -168,7 +169,32 @@ func recordSetCreate(c *cli.Context) error {
 				CName: rdata[0],
 			},
 		}
-	} else {
+  } else if t == "MX" {
+    i, err := strconv.Atoi(rdata[0])
+
+    if err != nil {
+      return error
+    }
+
+    records = []vinyldns.Record{
+      {
+        Preference: i,
+        Exchange: rdata[1],
+      },
+    }
+  } else if t == "PTR" {
+      records = []vinyldns.Record{
+        {
+          PTRDName: rdata[0],
+        },
+      }
+  } else if t == "TXT" {
+      records = []vinyldns.Record{
+        {
+          Text: rdata[0],
+        },
+      }
+  } else {
 		records = []vinyldns.Record{
 			{
 				Address: rdata[0],

--- a/src/record_sets.go
+++ b/src/record_sets.go
@@ -173,7 +173,7 @@ func recordSetCreate(c *cli.Context) error {
     i, err := strconv.Atoi(rdata[0])
 
     if err != nil {
-      return error
+      return err
     }
 
     records = []vinyldns.Record{

--- a/src/record_sets.go
+++ b/src/record_sets.go
@@ -15,8 +15,8 @@ package main
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
-  "strconv"
 
 	clitable "github.com/crackcomm/go-clitable"
 	"github.com/urfave/cli"
@@ -169,32 +169,32 @@ func recordSetCreate(c *cli.Context) error {
 				CName: rdata[0],
 			},
 		}
-  } else if t == "MX" {
-    i, err := strconv.Atoi(rdata[0])
+	} else if t == "MX" {
+		i, err := strconv.Atoi(rdata[0])
 
-    if err != nil {
-      return err
-    }
+		if err != nil {
+			return err
+		}
 
-    records = []vinyldns.Record{
-      {
-        Preference: i,
-        Exchange: rdata[1],
-      },
-    }
-  } else if t == "PTR" {
-      records = []vinyldns.Record{
-        {
-          PTRDName: rdata[0],
-        },
-      }
-  } else if t == "TXT" {
-      records = []vinyldns.Record{
-        {
-          Text: rdata[0],
-        },
-      }
-  } else {
+		records = []vinyldns.Record{
+			{
+				Preference: i,
+				Exchange:   rdata[1],
+			},
+		}
+	} else if t == "PTR" {
+		records = []vinyldns.Record{
+			{
+				PTRDName: rdata[0],
+			},
+		}
+	} else if t == "TXT" {
+		records = []vinyldns.Record{
+			{
+				Text: rdata[0],
+			},
+		}
+	} else {
 		records = []vinyldns.Record{
 			{
 				Address: rdata[0],

--- a/src/record_sets_helpers.go
+++ b/src/record_sets_helpers.go
@@ -22,12 +22,12 @@ func typeSwitch(t string) string {
 		return "AAAA"
 	case "CNAME", "cname":
 		return "CNAME"
-  case "MX", "mx":
-    return "MX"
-  case "PTR", "ptr":
-    return "PTR"
-  case "TXT", "txt":
-    return "TXT"
+	case "MX", "mx":
+		return "MX"
+	case "PTR", "ptr":
+		return "PTR"
+	case "TXT", "txt":
+		return "TXT"
 	}
 	return ""
 }

--- a/src/record_sets_helpers.go
+++ b/src/record_sets_helpers.go
@@ -22,6 +22,12 @@ func typeSwitch(t string) string {
 		return "AAAA"
 	case "CNAME", "cname":
 		return "CNAME"
+  case "MX", "mx":
+    return "MX"
+  case "PTR", "ptr":
+    return "PTR"
+  case "TXT", "txt":
+    return "TXT"
 	}
 	return ""
 }

--- a/tests/fixtures/record_set_create_mx
+++ b/tests/fixtures/record_set_create_mx
@@ -1,0 +1,1 @@
+Created record set some-mx

--- a/tests/fixtures/record_set_create_txt
+++ b/tests/fixtures/record_set_create_txt
@@ -1,0 +1,1 @@
+Created record set some-txt

--- a/tests/vinyldns_tests.bats
+++ b/tests/vinyldns_tests.bats
@@ -140,6 +140,32 @@ load test_helper
   [ "${output}" = "${fixture}" ]
 }
 
+@test "record-set-create (MX)" {
+  run $ew record-set-create \
+    --zone-name "ok." \
+    --record-set-name "some-mx" \
+    --record-set-type "mx" \
+    --record-set-ttl "123" \
+    --record-set-data "3,test.com"
+
+  fixture="$(cat tests/fixtures/record_set_create_mx)"
+
+  [ "${output}" = "${fixture}" ]
+}
+
+@test "record-set-create (TXT)" {
+  run $ew record-set-create \
+    --zone-name "ok." \
+    --record-set-name "some-txt" \
+    --record-set-type "TXT" \
+    --record-set-ttl "123" \
+    --record-set-data "test TXT"
+
+  fixture="$(cat tests/fixtures/record_set_create_txt)"
+
+  [ "${output}" = "${fixture}" ]
+}
+
 @test "zone-sync (when the zone exists)" {
   # wait until the recently-created zone is in a state where it can be synced again
   sleep 10


### PR DESCRIPTION
### Description of the Change

Added support for MX, PTR and TXT record types

### Why Should This Be In The Package?

These types (along with the already supported record types A, AAAA, CNAME) are the most commonly used record types.

### Benefits

Move closer to supporting all record types that are supported in the VinylDNS API.

### Possible Drawbacks

Still more record types to support but can do more in a later PR

### Verification Process

Added tests for MX and TXT. Did not add a test for PTR since it requires a reverse zone.