### PR TITLE
update zoneByName helper to use zoneNameEP

### DIFF
--- a/src/zones_helpers.go
+++ b/src/zones_helpers.go
@@ -20,18 +20,12 @@ import (
 
 func zoneByName(c *vinyldns.Client, name string) (vinyldns.Zone, error) {
 	var z vinyldns.Zone
-	zones, err := c.Zones()
+	zone, err := c.ZoneByName(name)
 	if err != nil {
 		return z, err
 	}
 
-	for _, zone := range zones {
-		if zone.Name == name {
-			return zone, nil
-		}
-	}
-
-	return z, fmt.Errorf("Zone %s not found", name)
+	return zone, nil
 }
 
 func getZoneID(c *vinyldns.Client, id, name string) (string, error) {


### PR DESCRIPTION
### Description of the Change

I believe the zone by name helper in the CLI precedes the zone by name API endpoint. The CLI endpoint currently retrieves the list of zones the requesting user has access to then looks for the given zone name in that list. That was mostly fine before the concept of shared zones was introduced in VinylDNS. Users don't have direct access to shared zones (unless they explicitly own the zones) but they do need the zone ID to add records to those zones. That's why we introduced the zone by name endpoint and allow shared zones to be returned, regardless of the requesting user's access to that zone. The go client already supports the zone by name endpoint so i updated the CLI helper to call the go endpoint.

### Why Should This Be In The Package?

Allows users to retrieve zone IDs for shared zones they don't own.

### Benefits

Uses the intentional API endpoint rather than a workaround to retrieve desired data. 

### Verification Process
I tested this locally. Started the VinylDNS API locally. Using the current CLI version I ran `zone --zone-name shared` and got `Zone shared not found`. I built the CLI with my changes and ran the command again and got the zone name, id and status.