### PR TITLE
add batch-change-create command

### DIFF
--- a/src/batch_changes.go
+++ b/src/batch_changes.go
@@ -19,6 +19,8 @@ import (
 	clitable "github.com/crackcomm/go-clitable"
 
 	"github.com/urfave/cli"
+
+  "github.com/vinyldns/go-vinyldns/vinyldns"
 )
 
 func batchChanges(c *cli.Context) error {
@@ -86,6 +88,27 @@ func batchChange(c *cli.Context) error {
 	} else {
 		fmt.Println("No batch change found with id: " + c.String("batch-change-id"))
 	}
+
+	return nil
+}
+
+func batchChangeCreate(c *cli.Context) error {
+	data := []byte(c.String("json"))
+	batchChange := &vinyldns.BatchRecordChange{}
+	if err := json.Unmarshal(data, &batchChange); err != nil {
+		return err
+	}
+	client := client(c)
+	create, err := client.BatchRecordChangeCreate(batchChange)
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(create)
+	}
+
+	fmt.Printf("Created batchChange\n")
 
 	return nil
 }

--- a/src/cli.go
+++ b/src/cli.go
@@ -384,6 +384,18 @@ func main() {
 				},
 			},
 		},
+    {
+      Name:        "batch-change-create",
+      Usage:       "batch-change-create --json <batchChangeJSON>",
+      Description: "Create a batch change",
+      Action:      batchChangeCreate,
+      Flags: []cli.Flag{
+        cli.StringFlag{
+          Name:  "json",
+          Usage: "The vinyldns JSON representing the batch change",
+        },
+      },
+    },
 	}
 	app.RunAndExitOnError()
 }

--- a/tests/fixtures/batch_change_create
+++ b/tests/fixtures/batch_change_create
@@ -1,0 +1,1 @@
+Created batch change 

--- a/tests/fixtures/batch_change_create_json
+++ b/tests/fixtures/batch_change_create_json
@@ -1,0 +1,13 @@
+{
+  "comments": "this is optional",
+  "ownerGroupId": "global-acl-group-id",
+  "changes": [{
+    "inputName": "test-cli.shared."
+    "changeType": "Add",
+    "type": "A",
+    "ttl": 7200,
+    "record": {
+      "address": "1.1.1.1"
+    }
+  }]
+}

--- a/tests/vinyldns_tests.bats
+++ b/tests/vinyldns_tests.bats
@@ -174,3 +174,12 @@ load test_helper
 
   $ew zone-sync --zone-name "ok." | grep "${fixture}"
 }
+
+@test "batch-change-create" {
+  run $ew batch-change-create \
+    --json "$(cat tests/fixtures/batch_change_create_json)"
+
+  fixture="$(cat tests/fixtures/batch_change_create)"
+
+  [ "${output}" = "${fixture}" ]
+}


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

added a `batch-change-create` create command that takes a single json argument to create a batch change. Uses the BatchRecordChangeCreate method from the go client.
