### PR TITLE
Added group-update functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ COMMANDS:
      groups              groups
      group               group --group-id <groupID>
      group-create        group-create --json <groupJSON>
+     group-update        group-update --json <groupJSON>
      group-delete        group-delete --group-id <groupID>
      group-admins        group-admins --group-id <groupID>
      group-members       group-members --group-id <groupID>

--- a/src/cli.go
+++ b/src/cli.go
@@ -89,6 +89,18 @@ func main() {
 			},
 		},
 		{
+			Name:        "group-update",
+			Usage:       "group-update --json <groupJSON>",
+			Description: "Update a vinyldns group",
+			Action:      groupUpdate,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "json",
+					Usage: "The vinyldns JSON representing the group",
+				},
+			},
+		},
+		{
 			Name:        "group-delete",
 			Usage:       "group-delete --group-id <groupID>",
 			Description: "Delete the targeted vinyldns group",

--- a/src/groups.go
+++ b/src/groups.go
@@ -100,6 +100,24 @@ func groupCreate(c *cli.Context) error {
 	return nil
 }
 
+func groupUpdate(c *cli.Context) error {
+	data := []byte(c.String("json"))
+	group := &vinyldns.Group{}
+	if err := json.Unmarshal(data, &group); err != nil {
+		return err
+	}
+	client := client(c)
+	updated, err := client.GroupUpdate(group.ID, group)
+	if err != nil {
+		return err
+	}
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(updated)
+	}
+	fmt.Printf("Updated group %s\n", updated.Name)
+	return nil
+}
+
 func groupDelete(c *cli.Context) error {
 	id := c.String("group-id")
 	client := client(c)

--- a/tests/fixtures/group_updated
+++ b/tests/fixtures/group_updated
@@ -1,0 +1,1 @@
+Updated group ok-group

--- a/tests/vinyldns_tests.bats
+++ b/tests/vinyldns_tests.bats
@@ -53,13 +53,10 @@ load test_helper
   fixture="$(cat tests/fixtures/group_updated)"
   ok_group=$($ew --op json group --name "ok-group")
   updated_group="$(echo ${ok_group} | sed 's/test@test.com/update@update.com/g')"
-  run $ew group-update \
-    --json "${updated_group}"
+  run $ew group-update --json "${updated_group}"
 
   [ "${output}" = "${fixture}" ]
 }
-
-
 
 @test "zones (when none exist)" {
   run $ew zones

--- a/tests/vinyldns_tests.bats
+++ b/tests/vinyldns_tests.bats
@@ -49,6 +49,18 @@ load test_helper
   $ew --output=json group --name "ok-group" | grep "${fixture}"
 }
 
+@test "group-update (when the group exists)" {
+  fixture="$(cat tests/fixtures/group_updated)"
+  ok_group=$($ew --op json group --name "ok-group")
+  updated_group="$(echo ${ok_group} | sed 's/test@test.com/update@update.com/g')"
+  run $ew group-update \
+    --json "${updated_group}"
+
+  [ "${output}" = "${fixture}" ]
+}
+
+
+
 @test "zones (when none exist)" {
   run $ew zones
 


### PR DESCRIPTION
### Description of the Change

Added the group-update command as per the request to accept a json representing the entire group.
Tested this by requesting a previously created group's json and changed the email address and submitted it back to group-update.

### Why Should This Be In The Package?

It adds the group-update function addressing an open issue.

### Benefits

Groups may be updated using the cli

### Possible Drawbacks

Not exactly fine grained access.

### Verification Process

A successful response was received from the API and I confirmed that the data changed.

### Applicable Issues (Optional)

Issue #45
