### PR TITLE
run 'go fmt' on src/*.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LOCAL_GO_PATH=`go env GOPATH`
 all: test stop-api docker build-releases
 
 install: build
-	mkdir -p $(PREFIX)/bin	
+	mkdir -p $(PREFIX)/bin
 	cp -v bin/$(NAME) $(PREFIX)/bin/$(NAME)
 
 uninstall:
@@ -50,7 +50,13 @@ bats:
 		git clone --depth 1 https://${BATS}.git ${LOCAL_GO_PATH}/src/${BATS}; \
 	fi
 
-test: build bats start-api
+test-fmt:
+	if [ `go fmt $(SRC) | wc -l` != "0" ]; then \
+		echo "fix go code formatting by running 'go fmt'."; \
+		exit 1; \
+	fi;
+
+test: test-fmt build bats start-api
 	go get -u golang.org/x/lint/golint
 	$(LOCAL_GO_PATH)/bin/golint -set_exit_status $(SRC)
 	go vet $(SRC)

--- a/src/batch_changes.go
+++ b/src/batch_changes.go
@@ -15,8 +15,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"strconv"
+	"strings"
 
 	clitable "github.com/crackcomm/go-clitable"
 
@@ -97,21 +97,20 @@ func batchChange(c *cli.Context) error {
 func changeList(chs []vinyldns.RecordChange) string {
 	changes := []string{}
 
-  for _, r := range chs {
-    recordData, _ := json.Marshal(&(r.Record))
+	for _, r := range chs {
+		recordData, _ := json.Marshal(&(r.Record))
 
-    changes = append(changes,
-      `"ChangeType" - `+r.ChangeType,
-      `"InputName" - `+r.InputName,
-      `"Type" - `+r.Type,
-      `"TTL" - `+strconv.Itoa(r.TTL),
-      `"Record" - `+string(recordData),
-      `"Status" - `+r.Status)
-  }
+		changes = append(changes,
+			`"ChangeType" - `+r.ChangeType,
+			`"InputName" - `+r.InputName,
+			`"Type" - `+r.Type,
+			`"TTL" - `+strconv.Itoa(r.TTL),
+			`"Record" - `+string(recordData),
+			`"Status" - `+r.Status)
+	}
 
-  return strings.Join(changes, "\n")
+	return strings.Join(changes, "\n")
 }
-
 
 func batchChangeCreate(c *cli.Context) error {
 	data := []byte(c.String("json"))
@@ -129,25 +128,25 @@ func batchChangeCreate(c *cli.Context) error {
 		return printJSON(bc)
 	}
 
-  formattedData := [][]string{
-    {"ID", bc.ID},
-    {"UserName", bc.UserName},
-    {"UserID", bc.UserID},
-    {"Status", bc.Status},
-    {"Comments", bc.Comments},
-    {"Changes", changeList(bc.Changes)},
-    {"CreatedTimestamp", bc.CreatedTimestamp},
-    {"OwnerGroupID", bc.OwnerGroupID},
-    {"ApprovalStatus", bc.ApprovalStatus},
-    {"ReviewerID", bc.ReviewerID},
-    {"ReviewerUserName", bc.ReviewerUserName},
-    {"ReviewerTimestamp", bc.ReviewTimestamp},
-    {"ReviewComment", bc.ReviewComment},
-    {"ScheduledTime", bc.ScheduledTime},
-    {"CancelledTimestamp", bc.CancelledTimestamp},
-  }
+	formattedData := [][]string{
+		{"ID", bc.ID},
+		{"UserName", bc.UserName},
+		{"UserID", bc.UserID},
+		{"Status", bc.Status},
+		{"Comments", bc.Comments},
+		{"Changes", changeList(bc.Changes)},
+		{"CreatedTimestamp", bc.CreatedTimestamp},
+		{"OwnerGroupID", bc.OwnerGroupID},
+		{"ApprovalStatus", bc.ApprovalStatus},
+		{"ReviewerID", bc.ReviewerID},
+		{"ReviewerUserName", bc.ReviewerUserName},
+		{"ReviewerTimestamp", bc.ReviewTimestamp},
+		{"ReviewComment", bc.ReviewComment},
+		{"ScheduledTime", bc.ScheduledTime},
+		{"CancelledTimestamp", bc.CancelledTimestamp},
+	}
 
-  printBasicTable(formattedData)
+	printBasicTable(formattedData)
 
 	return nil
 }


### PR DESCRIPTION
This fixes some Go formatting, standardizing on `go fmt`-style formatting.

This addresses issue #91.