### PR TITLE
stop splitting TXT data at commas

### DIFF
--- a/src/record_sets.go
+++ b/src/record_sets.go
@@ -262,7 +262,7 @@ func recordSetCreate(c *cli.Context) error {
 	} else if t == "TXT" {
 		records = []vinyldns.Record{
 			{
-				Text: rdata[0],
+				Text: rdataS,
 			},
 		}
 	} else {


### PR DESCRIPTION
### Description of the Change

This change uses the entire rdata field for TXT records. Currently this truncates the data at the first comma if it exists.

### Why Should This Be In The Package?

TXT data fields are free form and could potentially use commas.

### Benefits

Truncating TXT data is unexpected, a user would expect the record to contain all the data not just the part before the first comma.

### Possible Drawbacks

TXT records can be large. This gives more freedom to the users to put even more things in a TXT data record.

### Verification Process

Used the application to create text records with embedded commas without any issues

### Applicable Issues (Optional)
