### PR TITLE
Add missing CLI endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LATEST=${DOCKER_NAME}:latest
 
 BATS=github.com/sstephenson/bats
 VINYLDNS_REPO=github.com/vinyldns/vinyldns
-VINYLDNS_VERSION=0.9.10
+VINYLDNS_VERSION=0.21.6
 
 SOURCE_PATH:=$(ROOT_DIR)/src
 LOCAL_GO_PATH=`go env GOPATH`
@@ -75,13 +75,23 @@ start-api:
 			https://$(VINYLDNS_REPO) \
 		$(LOCAL_GO_PATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION); \
 	fi
-	$(LOCAL_GO_PATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION)/bin/docker-up-vinyldns.sh \
-		--api-only \
-		--version $(VINYLDNS_VERSION)
+	if [ -x "$(LOCAL_GO_PATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION)/quickstart/quickstart-vinyldns.sh" ]; then \
+		$(LOCAL_GO_PATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION)/quickstart/quickstart-vinyldns.sh \
+			--api-only \
+			--version-tag $(VINYLDNS_VERSION); \
+	else \
+		$(LOCAL_GO_PATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION)/bin/docker-up-vinyldns.sh \
+			--api-only \
+			--version $(VINYLDNS_VERSION); \
+	fi
 
 stop-api:
 	@set -euo pipefail
-	$(LOCAL_GO_PATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION)/bin/remove-vinyl-containers.sh
+	if [ -x "$(LOCAL_GO_PATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION)/utils/clean-vinyldns-containers.sh" ]; then \
+		$(LOCAL_GO_PATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION)/utils/clean-vinyldns-containers.sh; \
+	else \
+		$(LOCAL_GO_PATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION)/bin/remove-vinyl-containers.sh; \
+	fi
 
 bats:
 	@set -euo pipefail
@@ -117,5 +127,3 @@ docker-push:
 	@set -euo pipefail
 	docker push ${LATEST}
 	docker push ${IMG}
-
-

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/crackcomm/go-clitable v0.0.0-20151121230230-53bcff2fea36
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/urfave/cli v1.22.17
-	github.com/vinyldns/go-vinyldns v0.9.17
+	github.com/vinyldns/go-vinyldns v0.9.18
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/urfave/cli v1.22.17 h1:SYzXoiPfQjHBbkYxbew5prZHS1TOLT3ierW8SYLqtVQ=
 github.com/urfave/cli v1.22.17/go.mod h1:b0ht0aqgH/6pBYzzxURyrM4xXNgsoT/n2ZzwQiEhNVo=
-github.com/vinyldns/go-vinyldns v0.9.17 h1:hfPZfCaxcRBX6Gsgl42rLCeoal58/BH8kkvJShzjjdI=
-github.com/vinyldns/go-vinyldns v0.9.17/go.mod h1:pwWhE9K/leGDOIduVhRGvQ3ecVMHWRfEnKYUTEU3gB4=
+github.com/vinyldns/go-vinyldns v0.9.18 h1:U3Nl1NEeqhbaQ4W1+V6Qm6iSmAEfEHaOgN/zSV4DtNY=
+github.com/vinyldns/go-vinyldns v0.9.18/go.mod h1:pwWhE9K/leGDOIduVhRGvQ3ecVMHWRfEnKYUTEU3gB4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/batch_changes_review.go
+++ b/src/batch_changes_review.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+	"github.com/vinyldns/go-vinyldns/vinyldns"
+)
+
+func batchChangeApprove(c *cli.Context) error {
+	return batchChangeReview(c, "approve")
+}
+
+func batchChangeReject(c *cli.Context) error {
+	return batchChangeReview(c, "reject")
+}
+
+func batchChangeCancel(c *cli.Context) error {
+	return batchChangeReview(c, "cancel")
+}
+
+func batchChangeReview(c *cli.Context, action string) error {
+	changeID, err := getOption(c, "batch-change-id")
+	if err != nil {
+		return err
+	}
+
+	var review *vinyldns.BatchChangeReview
+	if comment := c.String("review-comment"); comment != "" {
+		review = &vinyldns.BatchChangeReview{ReviewComment: comment}
+	}
+
+	client := client(c)
+	var resp *vinyldns.BatchRecordChange
+	switch action {
+	case "approve":
+		resp, err = client.BatchRecordChangeApprove(changeID, review)
+	case "reject":
+		resp, err = client.BatchRecordChangeReject(changeID, review)
+	case "cancel":
+		resp, err = client.BatchRecordChangeCancel(changeID, review)
+	default:
+		return fmt.Errorf("unknown review action %q", action)
+	}
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(resp)
+	}
+
+	data := [][]string{
+		{"ID", resp.ID},
+		{"Status", resp.Status},
+		{"ApprovalStatus", resp.ApprovalStatus},
+		{"ReviewComment", resp.ReviewComment},
+		{"ReviewerUserName", resp.ReviewerUserName},
+	}
+
+	printBasicTable(data)
+	return nil
+}

--- a/src/cli.go
+++ b/src/cli.go
@@ -356,24 +356,6 @@ func main() {
 			},
 		},
 		{
-			Name:        "zone-details",
-			Usage:       "zone-details --zone-id <zoneID>",
-			Description: "view detailed zone info",
-			Action: func(c *cli.Context) error {
-				return requireAtLeast(c, zoneDetails, "zone-id", "zone-name")
-			},
-			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  "zone-id",
-					Usage: "The zone ID",
-				},
-				cli.StringFlag{
-					Name:  "zone-name",
-					Usage: "The zone name (an alternative to --zone-id)",
-				},
-			},
-		},
-		{
 			Name:        "zone-backend-ids",
 			Usage:       "zone-backend-ids",
 			Description: "List DNS backend IDs",

--- a/src/cli.go
+++ b/src/cli.go
@@ -607,6 +607,118 @@ func main() {
 			},
 		},
 		{
+			Name:        "record-set-ownership-request",
+			Usage:       "record-set-ownership-request --zone-id <zoneID> --record-set-id <recordSetID> --requested-owner-group-id <groupID>",
+			Description: "request record set ownership transfer",
+			Action: func(c *cli.Context) error {
+				return requireAtLeast(c, recordSetOwnershipRequest, "zone-id", "zone-name")
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "zone-id",
+					Usage: "The zone ID",
+				},
+				cli.StringFlag{
+					Name:  "zone-name",
+					Usage: "The zone name (an alternative to --zone-id)",
+				},
+				cli.StringFlag{
+					Name:     "record-set-id",
+					Usage:    "The record set ID",
+					Required: true,
+				},
+				cli.StringFlag{
+					Name:     "requested-owner-group-id",
+					Usage:    "The requested owner group ID",
+					Required: true,
+				},
+			},
+		},
+		{
+			Name:        "record-set-ownership-approve",
+			Usage:       "record-set-ownership-approve --zone-id <zoneID> --record-set-id <recordSetID> --requested-owner-group-id <groupID>",
+			Description: "approve record set ownership transfer",
+			Action: func(c *cli.Context) error {
+				return requireAtLeast(c, recordSetOwnershipApprove, "zone-id", "zone-name")
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "zone-id",
+					Usage: "The zone ID",
+				},
+				cli.StringFlag{
+					Name:  "zone-name",
+					Usage: "The zone name (an alternative to --zone-id)",
+				},
+				cli.StringFlag{
+					Name:     "record-set-id",
+					Usage:    "The record set ID",
+					Required: true,
+				},
+				cli.StringFlag{
+					Name:     "requested-owner-group-id",
+					Usage:    "The requested owner group ID",
+					Required: true,
+				},
+			},
+		},
+		{
+			Name:        "record-set-ownership-reject",
+			Usage:       "record-set-ownership-reject --zone-id <zoneID> --record-set-id <recordSetID> --requested-owner-group-id <groupID>",
+			Description: "reject record set ownership transfer",
+			Action: func(c *cli.Context) error {
+				return requireAtLeast(c, recordSetOwnershipReject, "zone-id", "zone-name")
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "zone-id",
+					Usage: "The zone ID",
+				},
+				cli.StringFlag{
+					Name:  "zone-name",
+					Usage: "The zone name (an alternative to --zone-id)",
+				},
+				cli.StringFlag{
+					Name:     "record-set-id",
+					Usage:    "The record set ID",
+					Required: true,
+				},
+				cli.StringFlag{
+					Name:     "requested-owner-group-id",
+					Usage:    "The requested owner group ID",
+					Required: true,
+				},
+			},
+		},
+		{
+			Name:        "record-set-ownership-cancel",
+			Usage:       "record-set-ownership-cancel --zone-id <zoneID> --record-set-id <recordSetID> --requested-owner-group-id <groupID>",
+			Description: "cancel record set ownership transfer",
+			Action: func(c *cli.Context) error {
+				return requireAtLeast(c, recordSetOwnershipCancel, "zone-id", "zone-name")
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "zone-id",
+					Usage: "The zone ID",
+				},
+				cli.StringFlag{
+					Name:  "zone-name",
+					Usage: "The zone name (an alternative to --zone-id)",
+				},
+				cli.StringFlag{
+					Name:     "record-set-id",
+					Usage:    "The record set ID",
+					Required: true,
+				},
+				cli.StringFlag{
+					Name:     "requested-owner-group-id",
+					Usage:    "The requested owner group ID",
+					Required: true,
+				},
+			},
+		},
+		{
 			Name:        "record-set",
 			Usage:       "record-set --zone-id <zoneID> --record-set-id <recordSetID>",
 			Description: "View record set details",

--- a/src/cli.go
+++ b/src/cli.go
@@ -57,6 +57,55 @@ func main() {
 	}
 	app.Commands = []cli.Command{
 		{
+			Name:        "ping",
+			Usage:       "ping",
+			Description: "Simple health check",
+			Action:      ping,
+		},
+		{
+			Name:        "health",
+			Usage:       "health",
+			Description: "Comprehensive health check",
+			Action:      health,
+		},
+		{
+			Name:        "color",
+			Usage:       "color",
+			Description: "Blue/green deployment status",
+			Action:      color,
+		},
+		{
+			Name:        "metrics-prometheus",
+			Usage:       "metrics-prometheus --name <metricName>",
+			Description: "Prometheus metrics export",
+			Action:      metricsPrometheus,
+			Flags: []cli.Flag{
+				cli.StringSliceFlag{
+					Name:  "name",
+					Usage: "Metric name (repeatable)",
+				},
+			},
+		},
+		{
+			Name:        "status",
+			Usage:       "status",
+			Description: "System processing status",
+			Action:      status,
+		},
+		{
+			Name:        "status-update",
+			Usage:       "status-update --processing-disabled <true|false>",
+			Description: "Enable/disable processing (admin)",
+			Action:      statusUpdate,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:     "processing-disabled",
+					Usage:    "Set processing disabled (true|false)",
+					Required: true,
+				},
+			},
+		},
+		{
 			Name:        "groups",
 			Usage:       "groups",
 			Description: "List all VinylDNS groups",
@@ -157,6 +206,25 @@ func main() {
 					Required: true,
 				},
 			},
+		},
+		{
+			Name:        "group-change",
+			Usage:       "group-change --group-change-id <groupChangeID>",
+			Description: "Retrieve a specific group change",
+			Action:      groupChange,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:     "group-change-id",
+					Usage:    "The group change ID",
+					Required: true,
+				},
+			},
+		},
+		{
+			Name:        "group-valid-domains",
+			Usage:       "group-valid-domains",
+			Description: "List valid email domains for group membership",
+			Action:      groupValidDomains,
 		},
 		{
 			Name:        "zones",
@@ -288,6 +356,30 @@ func main() {
 			},
 		},
 		{
+			Name:        "zone-details",
+			Usage:       "zone-details --zone-id <zoneID>",
+			Description: "view detailed zone info",
+			Action: func(c *cli.Context) error {
+				return requireAtLeast(c, zoneDetails, "zone-id", "zone-name")
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "zone-id",
+					Usage: "The zone ID",
+				},
+				cli.StringFlag{
+					Name:  "zone-name",
+					Usage: "The zone name (an alternative to --zone-id)",
+				},
+			},
+		},
+		{
+			Name:        "zone-backend-ids",
+			Usage:       "zone-backend-ids",
+			Description: "List DNS backend IDs",
+			Action:      zoneBackendIDs,
+		},
+		{
 			Name:        "zone-changes",
 			Usage:       "zone-changes --zone-changes <zoneID>",
 			Description: "view zone change history details",
@@ -296,6 +388,96 @@ func main() {
 				cli.StringFlag{
 					Name:     "zone-id",
 					Usage:    "The zone ID",
+					Required: true,
+				},
+			},
+		},
+		{
+			Name:        "zone-changes-failure",
+			Usage:       "zone-changes-failure",
+			Description: "view failed zone changes",
+			Action:      zoneChangesFailure,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "name-filter",
+					Usage: "The name filter for the zone",
+				},
+				cli.StringFlag{
+					Name:  "start-from",
+					Usage: "The start key of the page",
+				},
+				cli.StringFlag{
+					Name:  "max-items",
+					Usage: "The page limit",
+				},
+			},
+		},
+		{
+			Name:        "zones-deleted-changes",
+			Usage:       "zones-deleted-changes",
+			Description: "view deleted zone changes",
+			Action:      zonesDeletedChanges,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "name-filter",
+					Usage: "The name filter for the zone",
+				},
+				cli.StringFlag{
+					Name:  "start-from",
+					Usage: "The start key of the page",
+				},
+				cli.StringFlag{
+					Name:  "max-items",
+					Usage: "The page limit",
+				},
+				cli.StringFlag{
+					Name:  "ignore-access",
+					Usage: "Ignore access restrictions (true|false)",
+				},
+			},
+		},
+		{
+			Name:        "zone-acl-rule-create",
+			Usage:       "zone-acl-rule-create --zone-id <zoneID> --json <aclRuleJSON>",
+			Description: "Add an ACL rule to a zone",
+			Action: func(c *cli.Context) error {
+				return requireAtLeast(c, zoneACLRuleCreate, "zone-id", "zone-name")
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "zone-id",
+					Usage: "The zone ID",
+				},
+				cli.StringFlag{
+					Name:  "zone-name",
+					Usage: "The zone name (an alternative to --zone-id)",
+				},
+				cli.StringFlag{
+					Name:     "json",
+					Usage:    "The VinylDNS JSON representing the ACL rule",
+					Required: true,
+				},
+			},
+		},
+		{
+			Name:        "zone-acl-rule-delete",
+			Usage:       "zone-acl-rule-delete --zone-id <zoneID> --json <aclRuleJSON>",
+			Description: "Delete an ACL rule from a zone",
+			Action: func(c *cli.Context) error {
+				return requireAtLeast(c, zoneACLRuleDelete, "zone-id", "zone-name")
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "zone-id",
+					Usage: "The zone ID",
+				},
+				cli.StringFlag{
+					Name:  "zone-name",
+					Usage: "The zone name (an alternative to --zone-id)",
+				},
+				cli.StringFlag{
+					Name:     "json",
+					Usage:    "The VinylDNS JSON representing the ACL rule",
 					Required: true,
 				},
 			},
@@ -315,6 +497,99 @@ func main() {
 				cli.StringFlag{
 					Name:  "zone-name",
 					Usage: "The zone name (an alternative to --zone-id)",
+				},
+			},
+		},
+		{
+			Name:        "record-set-update",
+			Usage:       "record-set-update --json <recordSetJSON>",
+			Description: "update record set details",
+			Action:      recordSetUpdate,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:     "json",
+					Usage:    "The VinylDNS JSON representing the record set",
+					Required: true,
+				},
+			},
+		},
+		{
+			Name:        "record-set-count",
+			Usage:       "record-set-count --zone-id <zoneID>",
+			Description: "view record set count for a zone",
+			Action: func(c *cli.Context) error {
+				return requireAtLeast(c, recordSetCount, "zone-id", "zone-name")
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "zone-id",
+					Usage: "The zone ID",
+				},
+				cli.StringFlag{
+					Name:  "zone-name",
+					Usage: "The zone name (an alternative to --zone-id)",
+				},
+			},
+		},
+		{
+			Name:        "record-set-history",
+			Usage:       "record-set-history --zone-id <zoneID> --record-set-fqdn <fqdn> --record-set-type <type>",
+			Description: "view record set change history for a FQDN",
+			Action: func(c *cli.Context) error {
+				return requireAtLeast(c, recordSetHistory, "zone-id", "zone-name")
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "zone-id",
+					Usage: "The zone ID",
+				},
+				cli.StringFlag{
+					Name:  "zone-name",
+					Usage: "The zone name (an alternative to --zone-id)",
+				},
+				cli.StringFlag{
+					Name:     "record-set-fqdn",
+					Usage:    "The record set FQDN",
+					Required: true,
+				},
+				cli.StringFlag{
+					Name:     "record-set-type",
+					Usage:    "The record set type",
+					Required: true,
+				},
+				cli.StringFlag{
+					Name:  "start-from",
+					Usage: "The start key of the page",
+				},
+				cli.StringFlag{
+					Name:  "max-items",
+					Usage: "The page limit",
+				},
+			},
+		},
+		{
+			Name:        "record-set-changes-failure",
+			Usage:       "record-set-changes-failure --zone-id <zoneID>",
+			Description: "view failed record set changes for a zone",
+			Action: func(c *cli.Context) error {
+				return requireAtLeast(c, recordSetChangesFailure, "zone-id", "zone-name")
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "zone-id",
+					Usage: "The zone ID",
+				},
+				cli.StringFlag{
+					Name:  "zone-name",
+					Usage: "The zone name (an alternative to --zone-id)",
+				},
+				cli.StringFlag{
+					Name:  "start-from",
+					Usage: "The start key of the page",
+				},
+				cli.StringFlag{
+					Name:  "max-items",
+					Usage: "The page limit",
 				},
 			},
 		},
@@ -509,6 +784,101 @@ func main() {
 				cli.StringFlag{
 					Name:     "json",
 					Usage:    "The VinylDNS JSON representing the batch change",
+					Required: true,
+				},
+			},
+		},
+		{
+			Name:        "batch-change-approve",
+			Usage:       "batch-change-approve --batch-change-id <batchChangeID>",
+			Description: "Approve a batch change (manual review)",
+			Action:      batchChangeApprove,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:     "batch-change-id",
+					Usage:    "The batch change ID",
+					Required: true,
+				},
+				cli.StringFlag{
+					Name:  "review-comment",
+					Usage: "Review comment",
+				},
+			},
+		},
+		{
+			Name:        "batch-change-reject",
+			Usage:       "batch-change-reject --batch-change-id <batchChangeID>",
+			Description: "Reject a batch change (manual review)",
+			Action:      batchChangeReject,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:     "batch-change-id",
+					Usage:    "The batch change ID",
+					Required: true,
+				},
+				cli.StringFlag{
+					Name:  "review-comment",
+					Usage: "Review comment",
+				},
+			},
+		},
+		{
+			Name:        "batch-change-cancel",
+			Usage:       "batch-change-cancel --batch-change-id <batchChangeID>",
+			Description: "Cancel a batch change",
+			Action:      batchChangeCancel,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:     "batch-change-id",
+					Usage:    "The batch change ID",
+					Required: true,
+				},
+				cli.StringFlag{
+					Name:  "review-comment",
+					Usage: "Review comment",
+				},
+			},
+		},
+		{
+			Name:        "user",
+			Usage:       "user --user-id <userID>",
+			Description: "Retrieve user details",
+			Action: func(c *cli.Context) error {
+				return requireAtLeast(c, user, "user-id", "user-name")
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "user-id",
+					Usage: "The user ID",
+				},
+				cli.StringFlag{
+					Name:  "user-name",
+					Usage: "The user name",
+				},
+			},
+		},
+		{
+			Name:        "user-lock",
+			Usage:       "user-lock --user-id <userID>",
+			Description: "Lock a user account (admin)",
+			Action:      userLock,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:     "user-id",
+					Usage:    "The user ID",
+					Required: true,
+				},
+			},
+		},
+		{
+			Name:        "user-unlock",
+			Usage:       "user-unlock --user-id <userID>",
+			Description: "Unlock a user account (admin)",
+			Action:      userUnlock,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:     "user-id",
+					Usage:    "The user ID",
 					Required: true,
 				},
 			},

--- a/src/cli.go
+++ b/src/cli.go
@@ -262,6 +262,10 @@ func main() {
 					Name:  "zone-id",
 					Usage: "The zone ID",
 				},
+				cli.StringFlag{
+					Name:  "zone-name",
+					Usage: "The zone name (an alternative to --zone-id)",
+				},
 			},
 		},
 		{

--- a/src/groups_extra.go
+++ b/src/groups_extra.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+)
+
+func groupChange(c *cli.Context) error {
+	client := client(c)
+	change, err := client.GroupChange(c.String("group-change-id"))
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(change)
+	}
+
+	data := [][]string{
+		{"ID", change.ID},
+		{"UserID", change.UserID},
+		{"UserName", change.UserName},
+		{"ChangeType", change.ChangeType},
+		{"Created", change.Created},
+		{"Message", change.GroupChangeMessage},
+	}
+	printBasicTable(data)
+
+	fmt.Println("\nNew Group...")
+	printGroup(change.NewGroup)
+	fmt.Println("\nOld Group...")
+	printGroup(change.OldGroup)
+
+	return nil
+}
+
+func groupValidDomains(c *cli.Context) error {
+	client := client(c)
+	domains, err := client.GroupValidDomains()
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(domains)
+	}
+
+	data := [][]string{}
+	for _, domain := range domains {
+		data = append(data, []string{domain})
+	}
+
+	if len(data) != 0 {
+		printTableWithHeaders([]string{"Domain"}, data)
+	} else {
+		fmt.Print("No domains found")
+	}
+
+	return nil
+}

--- a/src/health.go
+++ b/src/health.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+)
+
+func ping(c *cli.Context) error {
+	client := client(c)
+	resp, err := client.Ping()
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(resp)
+	}
+
+	fmt.Print(resp)
+	return nil
+}
+
+func health(c *cli.Context) error {
+	client := client(c)
+	if err := client.Health(); err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON("OK")
+	}
+
+	fmt.Print("OK")
+	return nil
+}
+
+func color(c *cli.Context) error {
+	client := client(c)
+	resp, err := client.Color()
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(resp)
+	}
+
+	fmt.Print(resp)
+	return nil
+}
+
+func metricsPrometheus(c *cli.Context) error {
+	client := client(c)
+	resp, err := client.MetricsPrometheus(c.StringSlice("name"))
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(resp)
+	}
+
+	fmt.Print(resp)
+	return nil
+}

--- a/src/helpers.go
+++ b/src/helpers.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
@@ -103,4 +104,27 @@ func printJSON(i interface{}) error {
 	fmt.Println(string(j))
 
 	return nil
+}
+
+func parseIntFlag(c *cli.Context, name string) (int, error) {
+	val := c.String(name)
+	if val == "" {
+		return 0, nil
+	}
+
+	return strconv.Atoi(val)
+}
+
+func parseBoolFlag(c *cli.Context, name string) (*bool, error) {
+	val := c.String(name)
+	if val == "" {
+		return nil, nil
+	}
+
+	parsed, err := strconv.ParseBool(val)
+	if err != nil {
+		return nil, err
+	}
+
+	return &parsed, nil
 }

--- a/src/record_sets_extra.go
+++ b/src/record_sets_extra.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/crackcomm/go-clitable"
+	"github.com/urfave/cli"
+	"github.com/vinyldns/go-vinyldns/vinyldns"
+)
+
+func recordSetUpdate(c *cli.Context) error {
+	data := []byte(c.String("json"))
+	rs := &vinyldns.RecordSet{}
+	if err := json.Unmarshal(data, &rs); err != nil {
+		return err
+	}
+	if rs.ZoneID == "" || rs.ID == "" {
+		return fmt.Errorf("record set JSON must include zoneId and id")
+	}
+
+	client := client(c)
+	updated, err := client.RecordSetUpdate(rs)
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(updated)
+	}
+
+	fmt.Printf("Updated record set %s\n", rs.ID)
+	return nil
+}
+
+func recordSetCount(c *cli.Context) error {
+	client := client(c)
+	zoneID, err := getZoneID(client, c.String("zone-id"), c.String("zone-name"))
+	if err != nil {
+		return err
+	}
+
+	count, err := client.RecordSetCount(zoneID)
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(count)
+	}
+
+	data := [][]string{
+		{"Count", strconv.Itoa(count.Count)},
+	}
+	printBasicTable(data)
+	return nil
+}
+
+func recordSetHistory(c *cli.Context) error {
+	client := client(c)
+	zoneID, err := getZoneID(client, c.String("zone-id"), c.String("zone-name"))
+	if err != nil {
+		return err
+	}
+
+	fqdn, err := getOption(c, "record-set-fqdn")
+	if err != nil {
+		return err
+	}
+	recordType, err := getOption(c, "record-set-type")
+	if err != nil {
+		return err
+	}
+
+	filter := vinyldns.RecordSetChangeHistoryFilter{
+		ZoneID:     zoneID,
+		FQDN:       fqdn,
+		RecordType: recordType,
+		StartFrom:  c.String("start-from"),
+	}
+	maxItems, err := parseIntFlag(c, "max-items")
+	if err != nil {
+		return err
+	}
+	filter.MaxItems = maxItems
+
+	history, err := client.RecordSetChangeHistory(filter)
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(history)
+	}
+
+	for _, change := range history.RecordSetChanges {
+		clitable.PrintHorizontal(map[string]interface{}{
+			"Zone":          change.Zone.Name,
+			"RecordSetName": change.RecordSet.Name,
+			"RecordSetID":   change.RecordSet.ID,
+			"UserID":        change.UserID,
+			"ChangeType":    change.ChangeType,
+			"Status":        change.Status,
+			"Created":       change.Created,
+			"ID":            change.ID,
+		})
+	}
+
+	return nil
+}
+
+func recordSetChangesFailure(c *cli.Context) error {
+	client := client(c)
+	zoneID, err := getZoneID(client, c.String("zone-id"), c.String("zone-name"))
+	if err != nil {
+		return err
+	}
+
+	filter := vinyldns.ListFilter{
+		StartFrom: c.String("start-from"),
+	}
+	maxItems, err := parseIntFlag(c, "max-items")
+	if err != nil {
+		return err
+	}
+	filter.MaxItems = maxItems
+
+	failures, err := client.RecordSetChangesFailure(zoneID, filter)
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(failures)
+	}
+
+	for _, change := range failures.FailedRecordSetChanges {
+		clitable.PrintHorizontal(map[string]interface{}{
+			"Zone":          change.Zone.Name,
+			"RecordSetName": change.RecordSet.Name,
+			"RecordSetID":   change.RecordSet.ID,
+			"UserID":        change.UserID,
+			"ChangeType":    change.ChangeType,
+			"Status":        change.Status,
+			"Created":       change.Created,
+			"ID":            change.ID,
+		})
+	}
+
+	return nil
+}

--- a/src/record_sets_ownership.go
+++ b/src/record_sets_ownership.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+)
+
+func recordSetOwnershipRequest(c *cli.Context) error {
+	return recordSetOwnershipTransfer(c, "request")
+}
+
+func recordSetOwnershipApprove(c *cli.Context) error {
+	return recordSetOwnershipTransfer(c, "approve")
+}
+
+func recordSetOwnershipReject(c *cli.Context) error {
+	return recordSetOwnershipTransfer(c, "reject")
+}
+
+func recordSetOwnershipCancel(c *cli.Context) error {
+	return recordSetOwnershipTransfer(c, "cancel")
+}
+
+func recordSetOwnershipTransfer(c *cli.Context, action string) error {
+	client := client(c)
+	zoneID, err := getZoneID(client, c.String("zone-id"), c.String("zone-name"))
+	if err != nil {
+		return err
+	}
+
+	recordSetID, err := getOption(c, "record-set-id")
+	if err != nil {
+		return err
+	}
+
+	requestedOwnerGroupID, err := getOption(c, "requested-owner-group-id")
+	if err != nil {
+		return err
+	}
+
+	rs, err := client.RecordSet(zoneID, recordSetID)
+	if err != nil {
+		return err
+	}
+
+	if rs.ZoneID == "" {
+		rs.ZoneID = zoneID
+	}
+	if rs.ID == "" {
+		rs.ID = recordSetID
+	}
+
+	switch action {
+	case "request":
+		_, err = client.RecordSetOwnershipTransferRequest(&rs, requestedOwnerGroupID)
+	case "approve":
+		_, err = client.RecordSetOwnershipTransferApprove(&rs, requestedOwnerGroupID)
+	case "reject":
+		_, err = client.RecordSetOwnershipTransferReject(&rs, requestedOwnerGroupID)
+	case "cancel":
+		_, err = client.RecordSetOwnershipTransferCancel(&rs, requestedOwnerGroupID)
+	default:
+		return fmt.Errorf("unknown ownership transfer action %q", action)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON("OK")
+	}
+
+	fmt.Printf("Updated record set %s\n", recordSetID)
+	return nil
+}

--- a/src/status.go
+++ b/src/status.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/urfave/cli"
+)
+
+func status(c *cli.Context) error {
+	client := client(c)
+	s, err := client.Status()
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(s)
+	}
+
+	data := [][]string{
+		{"ProcessingDisabled", fmt.Sprintf("%t", s.ProcessingDisabled)},
+		{"Color", s.Color},
+		{"KeyName", s.KeyName},
+		{"Version", s.Version},
+	}
+
+	printBasicTable(data)
+	return nil
+}
+
+func statusUpdate(c *cli.Context) error {
+	processingDisabledRaw, err := getOption(c, "processing-disabled")
+	if err != nil {
+		return err
+	}
+
+	processingDisabled, err := strconv.ParseBool(processingDisabledRaw)
+	if err != nil {
+		return err
+	}
+
+	client := client(c)
+	s, err := client.StatusUpdate(processingDisabled)
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(s)
+	}
+
+	data := [][]string{
+		{"ProcessingDisabled", fmt.Sprintf("%t", s.ProcessingDisabled)},
+		{"Color", s.Color},
+		{"KeyName", s.KeyName},
+		{"Version", s.Version},
+	}
+
+	printBasicTable(data)
+	return nil
+}

--- a/src/users.go
+++ b/src/users.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/urfave/cli"
+	"github.com/vinyldns/go-vinyldns/vinyldns"
+)
+
+func user(c *cli.Context) error {
+	identifier := c.String("user-id")
+	if identifier == "" {
+		identifier = c.String("user-name")
+	}
+	if identifier == "" {
+		return fmt.Errorf("one of the flags must be provided: '--user-id', '--user-name'")
+	}
+
+	client := client(c)
+	u, err := client.User(identifier)
+	if err != nil {
+		return err
+	}
+
+	return printUserInfo(c, u)
+}
+
+func userLock(c *cli.Context) error {
+	identifier, err := getOption(c, "user-id")
+	if err != nil {
+		return err
+	}
+
+	client := client(c)
+	u, err := client.UserLock(identifier)
+	if err != nil {
+		return err
+	}
+
+	return printUserInfo(c, u)
+}
+
+func userUnlock(c *cli.Context) error {
+	identifier, err := getOption(c, "user-id")
+	if err != nil {
+		return err
+	}
+
+	client := client(c)
+	u, err := client.UserUnlock(identifier)
+	if err != nil {
+		return err
+	}
+
+	return printUserInfo(c, u)
+}
+
+func printUserInfo(c *cli.Context, u vinyldns.UserInfo) error {
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(u)
+	}
+
+	data := [][]string{
+		{"ID", u.ID},
+		{"UserName", u.UserName},
+		{"LockStatus", u.LockStatus},
+		{"GroupIDs", joinUserGroupIDs(u)},
+	}
+
+	printBasicTable(data)
+	return nil
+}
+
+func joinUserGroupIDs(u vinyldns.UserInfo) string {
+	ids := make([]string, 0, len(u.GroupID))
+	for _, g := range u.GroupID {
+		if g != "" {
+			ids = append(ids, g)
+		}
+	}
+
+	return strings.Join(ids, ", ")
+}

--- a/src/zones.go
+++ b/src/zones.go
@@ -75,7 +75,10 @@ func zone(c *cli.Context) error {
 
 func zoneDetails(c *cli.Context) error {
 	client := client(c)
-	id := c.String("zone-id")
+	id, err := getZoneID(client, c.String("zone-id"), c.String("zone-name"))
+	if err != nil {
+		return err
+	}
 	z, err := getZoneDetails(client, id)
 	if err != nil {
 		return err

--- a/src/zones.go
+++ b/src/zones.go
@@ -253,6 +253,10 @@ func zoneChanges(c *cli.Context) error {
 func zoneSync(c *cli.Context) error {
 	client := client(c)
 	id, err := getZoneID(client, c.String("zone-id"), c.String("zone-name"))
+	if err != nil {
+		return err
+	}
+
 	z, err := client.ZoneSync(id)
 	if err != nil {
 		return err

--- a/src/zones_extra.go
+++ b/src/zones_extra.go
@@ -112,7 +112,8 @@ func zonesDeletedChanges(c *cli.Context) error {
 }
 
 func zoneACLRuleCreate(c *cli.Context) error {
-	zoneID, err := getZoneID(client(c), c.String("zone-id"), c.String("zone-name"))
+	client := client(c)
+	zoneID, err := getZoneID(client, c.String("zone-id"), c.String("zone-name"))
 	if err != nil {
 		return err
 	}
@@ -123,7 +124,6 @@ func zoneACLRuleCreate(c *cli.Context) error {
 		return err
 	}
 
-	client := client(c)
 	updated, err := client.ZoneACLRuleCreate(zoneID, rule)
 	if err != nil {
 		return err
@@ -142,7 +142,8 @@ func zoneACLRuleCreate(c *cli.Context) error {
 }
 
 func zoneACLRuleDelete(c *cli.Context) error {
-	zoneID, err := getZoneID(client(c), c.String("zone-id"), c.String("zone-name"))
+	client := client(c)
+	zoneID, err := getZoneID(client, c.String("zone-id"), c.String("zone-name"))
 	if err != nil {
 		return err
 	}
@@ -153,7 +154,6 @@ func zoneACLRuleDelete(c *cli.Context) error {
 		return err
 	}
 
-	client := client(c)
 	updated, err := client.ZoneACLRuleDelete(zoneID, rule)
 	if err != nil {
 		return err

--- a/src/zones_extra.go
+++ b/src/zones_extra.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/crackcomm/go-clitable"
+	"github.com/urfave/cli"
+	"github.com/vinyldns/go-vinyldns/vinyldns"
+)
+
+func zoneBackendIDs(c *cli.Context) error {
+	client := client(c)
+	ids, err := client.ZoneBackendIDs()
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(ids)
+	}
+
+	data := [][]string{}
+	for _, id := range ids {
+		data = append(data, []string{id})
+	}
+
+	if len(data) != 0 {
+		printTableWithHeaders([]string{"BackendID"}, data)
+	} else {
+		fmt.Print("No backend IDs found")
+	}
+
+	return nil
+}
+
+func zoneChangesFailure(c *cli.Context) error {
+	filter, err := listFilterFromContext(c)
+	if err != nil {
+		return err
+	}
+
+	client := client(c)
+	resp, err := client.ZoneChangesFailure(filter)
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(resp)
+	}
+
+	for _, change := range resp.FailedZoneChanges {
+		clitable.PrintHorizontal(map[string]interface{}{
+			"Zone":       change.Zone.Name,
+			"ZoneID":     change.Zone.ID,
+			"UserID":     change.UserID,
+			"ChangeType": change.ChangeType,
+			"Status":     change.Status,
+			"Created":    change.Created,
+			"ID":         change.ID,
+		})
+	}
+
+	return nil
+}
+
+func zonesDeletedChanges(c *cli.Context) error {
+	filter, err := deletedZonesFilterFromContext(c)
+	if err != nil {
+		return err
+	}
+
+	client := client(c)
+	resp, err := client.ZonesDeleted(filter)
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(resp)
+	}
+
+	for _, info := range resp.ZonesDeletedInfo {
+		clitable.PrintHorizontal(map[string]interface{}{
+			"Zone":           info.ZoneChange.Zone.Name,
+			"ZoneID":         info.ZoneChange.Zone.ID,
+			"UserID":         info.ZoneChange.UserID,
+			"ChangeType":     info.ZoneChange.ChangeType,
+			"Status":         info.ZoneChange.Status,
+			"Created":        info.ZoneChange.Created,
+			"ID":             info.ZoneChange.ID,
+			"AdminGroupName": info.AdminGroupName,
+			"UserName":       info.UserName,
+			"AccessLevel":    info.AccessLevel,
+		})
+	}
+
+	return nil
+}
+
+func zoneACLRuleCreate(c *cli.Context) error {
+	zoneID, err := getZoneID(client(c), c.String("zone-id"), c.String("zone-name"))
+	if err != nil {
+		return err
+	}
+
+	data := []byte(c.String("json"))
+	rule := &vinyldns.ACLRule{}
+	if err := json.Unmarshal(data, &rule); err != nil {
+		return err
+	}
+
+	client := client(c)
+	updated, err := client.ZoneACLRuleCreate(zoneID, rule)
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(updated)
+	}
+
+	zoneName := updated.Zone.Name
+	if zoneName == "" {
+		zoneName = zoneID
+	}
+	fmt.Printf("Updated zone %s\n", zoneName)
+	return nil
+}
+
+func zoneACLRuleDelete(c *cli.Context) error {
+	zoneID, err := getZoneID(client(c), c.String("zone-id"), c.String("zone-name"))
+	if err != nil {
+		return err
+	}
+
+	data := []byte(c.String("json"))
+	rule := &vinyldns.ACLRule{}
+	if err := json.Unmarshal(data, &rule); err != nil {
+		return err
+	}
+
+	client := client(c)
+	updated, err := client.ZoneACLRuleDelete(zoneID, rule)
+	if err != nil {
+		return err
+	}
+
+	if c.GlobalString(outputFlag) == "json" {
+		return printJSON(updated)
+	}
+
+	zoneName := updated.Zone.Name
+	if zoneName == "" {
+		zoneName = zoneID
+	}
+	fmt.Printf("Updated zone %s\n", zoneName)
+	return nil
+}
+
+func listFilterFromContext(c *cli.Context) (vinyldns.ListFilter, error) {
+	filter := vinyldns.ListFilter{
+		NameFilter: c.String("name-filter"),
+		StartFrom:  c.String("start-from"),
+	}
+
+	maxItems, err := parseIntFlag(c, "max-items")
+	if err != nil {
+		return filter, err
+	}
+	filter.MaxItems = maxItems
+	return filter, nil
+}
+
+func deletedZonesFilterFromContext(c *cli.Context) (vinyldns.DeletedZonesFilter, error) {
+	filter := vinyldns.DeletedZonesFilter{
+		NameFilter: c.String("name-filter"),
+		StartFrom:  c.String("start-from"),
+	}
+
+	maxItems, err := parseIntFlag(c, "max-items")
+	if err != nil {
+		return filter, err
+	}
+	filter.MaxItems = maxItems
+
+	ignoreAccess, err := parseBoolFlag(c, "ignore-access")
+	if err != nil {
+		return filter, err
+	}
+	filter.IgnoreAccess = ignoreAccess
+	return filter, nil
+}

--- a/tests/fixtures/batch_change_create_json
+++ b/tests/fixtures/batch_change_create_json
@@ -1,5 +1,6 @@
 {
   "comments": "request on behalf of someone.",
+  "ownerGroupId": "ok-group-id",
   "changes": [{
     "inputName": "test-cli.ok.",
     "changeType": "Add",

--- a/tests/vinyldns_tests.bats
+++ b/tests/vinyldns_tests.bats
@@ -335,6 +335,46 @@ load test_helper
   echo "$output" | grep "/zones/does-not-exist/recordsets/does-not-exist"
 }
 
+@test "record-set-ownership-request (unknown record set)" {
+  run $ew record-set-ownership-request \
+    --zone-id "does-not-exist" \
+    --record-set-id "does-not-exist" \
+    --requested-owner-group-id "group-does-not-exist"
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "/zones/does-not-exist/recordsets/does-not-exist"
+}
+
+@test "record-set-ownership-approve (unknown record set)" {
+  run $ew record-set-ownership-approve \
+    --zone-id "does-not-exist" \
+    --record-set-id "does-not-exist" \
+    --requested-owner-group-id "group-does-not-exist"
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "/zones/does-not-exist/recordsets/does-not-exist"
+}
+
+@test "record-set-ownership-reject (unknown record set)" {
+  run $ew record-set-ownership-reject \
+    --zone-id "does-not-exist" \
+    --record-set-id "does-not-exist" \
+    --requested-owner-group-id "group-does-not-exist"
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "/zones/does-not-exist/recordsets/does-not-exist"
+}
+
+@test "record-set-ownership-cancel (unknown record set)" {
+  run $ew record-set-ownership-cancel \
+    --zone-id "does-not-exist" \
+    --record-set-id "does-not-exist" \
+    --requested-owner-group-id "group-does-not-exist"
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "/zones/does-not-exist/recordsets/does-not-exist"
+}
+
 @test "group-change (unknown group change)" {
   run $ew group-change --group-change-id "does-not-exist"
 

--- a/tests/vinyldns_tests.bats
+++ b/tests/vinyldns_tests.bats
@@ -45,7 +45,7 @@ load test_helper
 @test "group-update (when the group exists)" {
   fixture="$(cat tests/fixtures/group_updated)"
   ok_group=$($ew --op json group --name "ok-group")
-  updated_group="$(echo ${ok_group} | sed 's/test@test.com/update@update.com/g')"
+  updated_group="$(echo ${ok_group} | sed 's/test@test.com/update@test.com/g')"
   run $ew group-update --json "${updated_group}"
 
   [ "${output}" = "${fixture}" ]
@@ -74,10 +74,10 @@ load test_helper
     --admin-group-name "ok-group" \
     --zone-connection-key-name "vinyldns." \
     --zone-connection-key "nzisn+4G2ldMn0q1CV3vsg==" \
-    --zone-connection-primary-server "vinyldns-bind9" \
+    --zone-connection-primary-server "vinyldns-integration:19001" \
     --transfer-connection-key-name "vinyldns." \
     --transfer-connection-key "nzisn+4G2ldMn0q1CV3vsg==" \
-    --transfer-connection-primary-server "vinyldns-bind9"
+    --transfer-connection-primary-server "vinyldns-integration:19001"
 
   fixture="$(cat tests/fixtures/zone_create_connection)"
 
@@ -101,7 +101,7 @@ load test_helper
     --email "test@test.com" \
     --admin-group-name "ok-group" \
     --zone-connection-key "nzisn+4G2ldMn0q1CV3vsg==" \
-    --zone-connection-primary-server "vinyldns-bind9"
+    --zone-connection-primary-server "vinyldns-integration:19001"
 
   fixture="$(cat tests/fixtures/zone_create_invalid_zone_connection)"
 
@@ -115,7 +115,7 @@ load test_helper
     --email "test@test.com" \
     --admin-group-name "ok-group" \
     --transfer-connection-key "nzisn+4G2ldMn0q1CV3vsg==" \
-    --transfer-connection-primary-server "vinyldns-bind9"
+    --transfer-connection-primary-server "vinyldns-integration:19001"
 
   fixture="$(cat tests/fixtures/zone_create_invalid_transfer_connection)"
 
@@ -132,7 +132,7 @@ load test_helper
 @test "update zone (when the zone exists)" {
   fixture="$(cat tests/fixtures/zone_updated)"
   ok_zone=$($ew --op json zone --zone-name "ok.")
-  updated_zone="$(echo ${ok_zone} | sed 's/test@test.com/update@update.com/g')"
+  updated_zone="$(echo ${ok_zone} | sed 's/test@test.com/update@test.com/g')"
   run $ew zone-update \
     --json "${updated_zone}"
 
@@ -209,8 +209,11 @@ load test_helper
 }
 
 @test "batch-change-create" {
+  ok_group_id="$($ew --op json group --name "ok-group" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')"
+  batch_change_json="$(sed "s/ok-group-id/${ok_group_id}/g" tests/fixtures/batch_change_create_json)"
+
   run $ew batch-change-create \
-    --json "$(cat tests/fixtures/batch_change_create_json)"
+    --json "${batch_change_json}"
 
   [ "$status" -eq 0 ]
 }

--- a/tests/vinyldns_tests.bats
+++ b/tests/vinyldns_tests.bats
@@ -209,7 +209,7 @@ load test_helper
 }
 
 @test "batch-change-create" {
-  ok_group_id="$($ew --op json group --name "ok-group" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')"
+  ok_group_id="$($ew --op json group --name "ok-group" | sed -n 's/^{"id":"\([^"]*\)".*/\1/p')"
   batch_change_json="$(sed "s/ok-group-id/${ok_group_id}/g" tests/fixtures/batch_change_create_json)"
 
   run $ew batch-change-create \

--- a/tests/vinyldns_tests.bats
+++ b/tests/vinyldns_tests.bats
@@ -214,3 +214,179 @@ load test_helper
 
   [ "$status" -eq 0 ]
 }
+
+@test "ping" {
+  run $ew ping
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "PONG" ]
+}
+
+@test "health" {
+  run $ew health
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "OK" ]
+}
+
+@test "color" {
+  run $ew color
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -E "blue|green"
+}
+
+@test "metrics-prometheus" {
+  run $ew metrics-prometheus
+
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}
+
+@test "status" {
+  run $ew --output=json status
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep '"processingDisabled"'
+}
+
+@test "status-update (requires admin)" {
+  run $ew status-update --processing-disabled true
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "/status?processingDisabled=true"
+}
+
+@test "zone-backend-ids" {
+  run $ew --output=json zone-backend-ids
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep '\['
+}
+
+@test "zone-details" {
+  run $ew --output=json zone-details --zone-name "ok."
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep '"name":"ok\.'
+}
+
+@test "zone-changes-failure" {
+  run $ew --output=json zone-changes-failure
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep '"failedZoneChanges"'
+}
+
+@test "zones-deleted-changes" {
+  run $ew --output=json zones-deleted-changes
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep '"zonesDeletedInfo"'
+}
+
+@test "zone-acl-rule-create (unknown zone)" {
+  run $ew zone-acl-rule-create \
+    --zone-id "does-not-exist" \
+    --json '{"accessLevel":"Read","recordTypes":["A"],"groupId":"global-acl-group-id"}'
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "/zones/does-not-exist/acl/rules"
+}
+
+@test "zone-acl-rule-delete (unknown zone)" {
+  run $ew zone-acl-rule-delete \
+    --zone-id "does-not-exist" \
+    --json '{"accessLevel":"Read","recordTypes":["A"],"groupId":"global-acl-group-id"}'
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "/zones/does-not-exist/acl/rules"
+}
+
+@test "record-set-count" {
+  run $ew --output=json record-set-count --zone-name "ok."
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep '"count"'
+}
+
+@test "record-set-history" {
+  run $ew --output=json record-set-history \
+    --zone-name "ok." \
+    --record-set-fqdn "some-cname.ok." \
+    --record-set-type "CNAME"
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep '"recordSetChanges"'
+}
+
+@test "record-set-changes-failure" {
+  run $ew --output=json record-set-changes-failure --zone-name "ok."
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep '"failedRecordSetChanges"'
+}
+
+@test "record-set-update (unknown record set)" {
+  run $ew record-set-update \
+    --json '{"zoneId":"does-not-exist","id":"does-not-exist","name":"nope","type":"CNAME","ttl":300,"records":[{"cname":"test.com"}]}'
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "/zones/does-not-exist/recordsets/does-not-exist"
+}
+
+@test "group-change (unknown group change)" {
+  run $ew group-change --group-change-id "does-not-exist"
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "/groups/change/does-not-exist"
+}
+
+@test "group-valid-domains" {
+  run $ew --output=json group-valid-domains
+
+  [ "$status" -eq 0 ]
+  echo "$output" | grep '\['
+}
+
+@test "user (unknown user)" {
+  run $ew user --user-id "does-not-exist"
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "/users/does-not-exist"
+}
+
+@test "user-lock (unknown user)" {
+  run $ew user-lock --user-id "does-not-exist"
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "/users/does-not-exist/lock"
+}
+
+@test "user-unlock (unknown user)" {
+  run $ew user-unlock --user-id "does-not-exist"
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "/users/does-not-exist/unlock"
+}
+
+@test "batch-change-approve (unknown batch change)" {
+  run $ew batch-change-approve --batch-change-id "does-not-exist"
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "/zones/batchrecordchanges/does-not-exist/approve"
+}
+
+@test "batch-change-reject (unknown batch change)" {
+  run $ew batch-change-reject --batch-change-id "does-not-exist"
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "/zones/batchrecordchanges/does-not-exist/reject"
+}
+
+@test "batch-change-cancel (unknown batch change)" {
+  run $ew batch-change-cancel --batch-change-id "does-not-exist"
+
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "/zones/batchrecordchanges/does-not-exist/cancel"
+}


### PR DESCRIPTION
## Summary
- add CLI commands for health/status/metrics endpoints (ping/health/color/metrics-prometheus/status/status-update)
- add CLI commands for zone extras (details, backend IDs, deleted changes, failed changes, ACL rule add/delete)
- add CLI commands for record set extras (update, count, history, failed changes)
- add CLI commands for ownership transfer (request/approve/reject/cancel)
- add CLI commands for group/user extras (group-change, group-valid-domains, user, user-lock, user-unlock)
- add CLI commands for batch review (approve/reject/cancel)
- extend Bats suite with coverage for new commands and error-path checks

## Dependency
- updated `github.com/vinyldns/go-vinyldns` to `v0.9.18`, which includes the client methods needed by these commands
- removed the need for a local `go.mod` replace now that the go-vinyldns changes have been released

## Test/CI Updates
- updated acceptance tests to run against VinylDNS `0.21.6`, since the old `0.9.10` test API does not expose several endpoints covered by this PR
- updated the Makefile test harness to support the newer VinylDNS quickstart script layout while retaining the old script fallback
- adjusted Bats fixtures for current VinylDNS validation rules and quickstart defaults

## Validation
- GitHub Actions build is passing
- CLA is passing
- Snyk security and license checks are passing
- local compile check: `go test ./...`

VDNS-253
